### PR TITLE
Fixes layout of theme previews on admin page

### DIFF
--- a/bp-groupblog-admin.php
+++ b/bp-groupblog-admin.php
@@ -468,10 +468,38 @@ function bp_groupblog_management_page() {
 						</select>
 					</div>
 
-					<?php if ( !empty( $current_groupblog_theme ) ) : ?>
+					<?php if ( !empty( $current_groupblog_theme ) ) : 
+						
+						// set a class for WP3.4+ which has bigger screenshots
+						$wp3point4class = '';
+						if ( function_exists( 'wp_get_themes' ) ) {
+							$wp3point4class = 'current-theme-3point4plus';
+						}
+						
+						// not all themes have screenshots
+						$theme_has_screenshot = false;
+						if ( 
+							isset( $themes[$current_groupblog_theme]['Screenshot'] ) && 
+							$themes[$current_groupblog_theme]['Screenshot'] != '' 
+						) {
+							$theme_has_screenshot = true;
+						}
+						
+						// add class to container if theme has screenshot
+						if ( $theme_has_screenshot ) {
+							$wp3point4class .= ' current-theme-has-screenshot';
+						}
+						
+						// construct attribute
+						$wp3point4classes = '';
+						if ( $wp3point4class != '' ) {
+							$wp3point4classes = ' class="' . $wp3point4class . '"';
+						}
+						
+						?>
 
-						<div id="current-theme">
-							<?php if ( isset( $themes[$current_groupblog_theme]['Screenshot'] ) ) : ?>
+						<div id="current-theme"<?php echo $wp3point4classes; ?>>
+							<?php if ( $theme_has_screenshot ) : ?>
 								<img src="<?php echo $themes[$current_groupblog_theme]['Theme Root URI'] . '/' . $themes[$current_groupblog_theme]['Stylesheet'] . '/' . $themes[$current_groupblog_theme]['Screenshot']; ?>" alt="<?php _e('Current theme preview'); ?>" />
 							<?php endif; ?>
 

--- a/inc/css/admin.css
+++ b/inc/css/admin.css
@@ -15,13 +15,15 @@
 #current-theme-info h4 {
 	margin-top: 6px;
 }
-/* screenshots in WP3.4+ are larger */
+/* fix layout of screenshots in WP3.4+ */
 #current-theme.current-theme-3point4plus img {
-	float: none;
 	margin-left: 0;
 }
 #current-theme.current-theme-3point4plus #current-theme-info {
 	margin-left: 0;
+}
+#current-theme.current-theme-has-screenshot #current-theme-info {
+	margin-left: 320px;
 }
 span.indent {
 	width: 170px;


### PR DESCRIPTION
Most of the CSS to do this was committed to the 1.7.x branch, but the logic seems to have been lost in the 1.8.x branch. Recommitting that logic.

Cheers,

Christian
