### PR TITLE
don't suggest subdomain names of longer than 50 chars, fixes #27

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -652,6 +652,12 @@ function bp_groupblog_show_blog_form( $blogname = '', $blog_title = '', $errors 
 
 				<?php $blog_address = isset( $_GET['invalid_address'] ) ? urldecode( $_GET['invalid_address'] ) : bp_groupblog_sanitize_blog_name( $bp->groups->current_group->slug ) ?>
 
+				<?php 
+					// Don't suggest a subdomain if it's really long,
+					// since subdomains longer than 63 chars won't work. 
+					if (strlen($blog_address > 50)) $blog_address = ""; 
+				?> 
+
 				<?php if (is_subdomain_install()) : ?>
 					<span class="gbd-value"><em>http://</em><input name="blogname" type="text" id="blogname" value="<?php echo $blog_address; ?>" maxlength="50" /><em><?php echo $current_site->domain . $current_site->path ?></em></span>
 				<?php else : ?>


### PR DESCRIPTION
A quick hack to remove the suggested subdomain names that were causing issue #27. 
