### PR TITLE
Add "new_groupblog_post" activity type to "Posts" dropdown filter option

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1160,9 +1160,9 @@ add_action( 'delete_post', 'bp_groupblog_remove_post', 5 );
  *
  * @since 1.8.9
  *
- * @param str $qs The querystring for the BP loop
- * @param str $object The current object for the querystring
- * @return array Modified querystring
+ * @param string $qs The querystring for the BP loop
+ * @param string $object The current object for the querystring
+ * @return string Modified querystring
  */
 function bp_groupblog_override_new_blog_post_activity_filter( $qs, $object ) {
 	// not on the blogs object? stop now!


### PR DESCRIPTION
When the "Posts" option is selected in the activity dropdown filter, it only filters activity items by blog posts and not groupblog posts.

This commit allows both types of blog posts to be filtered in the activity loop when the "Posts" activity filter is selected.

Let me know what you think.
