### PR TITLE
Add missing params to `groups_details_updated` action

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -259,7 +259,17 @@ function groupblog_edit_base_settings( $groupblog_enable_blog, $groupblog_silent
 		bp_groupblog_member_join( $group_id );
 	}
 
-	do_action( 'groups_details_updated', $group_id );
+	/**
+	 * Fired after a group's details are updated.
+	 *
+	 * Hook signature changed in BuddyPress 2.2.0. Two new params added:
+	 * @see https://buddypress.trac.wordpress.org/changeset/9204
+	 *
+	 * @param int             $value          ID of the group.
+	 * @param BP_Groups_Group $old_group      Group object, before being modified.
+	 * @param bool            $notify_members Whether to send an email notification to members about the change.
+	 */
+	do_action( 'groups_details_updated', $group_id, new stdClass, null );
 
 	return true;
 }


### PR DESCRIPTION
The hook signature of the `groups_details_updated` action has changed in BuddyPress 2.2.0. Two new params added, see:
https://buddypress.trac.wordpress.org/changeset/9204

This PR adds default values that prevent `bp_groups_group_details_updated_add_activity()` from throwing a "missing parameters" error. Also copies in the docblock for the hook for reference.