### PR TITLE
Fix activity edit support for groupblog posts in BuddyPress 2.2

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -259,7 +259,7 @@ function groupblog_edit_base_settings( $groupblog_enable_blog, $groupblog_silent
 		bp_groupblog_member_join( $group_id );
 	}
 
-	do_action( 'groups_details_updated', $group_id );
+	do_action( 'groupblog_details_updated', $group_id );
 
 	return true;
 }

--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1162,10 +1162,8 @@ function bp_groupblog_set_group_to_post_activity( $activity, $args = array() ) {
 			return;
 		}
 
-		$activity->id = $id;
-
-		// @todo just in case another user edited the original author's post?
-		//$activity->user_id = $post->post_author;
+		$activity->id      = $id;
+		$activity->user_id = $post->post_author;
 
 		$activity->action = sprintf( __( '%s edited the blog post %s in the group %s:', 'groupblog'), bp_core_get_userlink( $post->post_author ), '<a href="' . get_permalink( $post->ID ) .'">' . $post->post_title . '</a>', '<a href="' . bp_get_group_permalink( $group ) . '">' . esc_attr( $group->name ) . '</a>' );
 


### PR DESCRIPTION
Changes in BuddyPress 2.2 to support custom post type activity recording broke how groupblog post activity items are saved during edits:
https://buddypress.trac.wordpress.org/browser/tags/2.2.1/src/bp-activity/bp-activity-actions.php?marks=797#L777
https://buddypress.trac.wordpress.org/browser/tags/2.2.1/src/bp-activity/bp-activity-functions.php?marks=1949,1952,1957#L1926

For BP 2.2+, this commit mirrors the edit functionality of `bp_activity_catch_transition_post_type_status()` and modifies `bp_groupblog_set_group_to_post_activity()` to look for some existing variables to prevent unnecessary queries.

Let me know what you think, @boonebgorges.

----

Commit 1246bd3 is a minor change to support changing the activity user ID if the post author is changed.