### PR TITLE
Update readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,6 @@ function bp_core_avatar_url() {
 == Changelog ==
 
 = 1.8.11 =
-=======
 * Removed duplicate CSS selector in nav item
 * Improved compatibility with BuddyPress 2.2.0
 


### PR DESCRIPTION
Removed multiple equals signs that cause a glitch in the changelog tab on WP.org