### PR TITLE
Enable comment activity recording

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1323,7 +1323,7 @@ add_filter( 'bp_activity_can_comment', 'bp_groupblog_activity_can_comment' );
  */
 function bp_groupblog_activity_permalink( $retval, $activity ) {
 	// not a groupblog post? stop now!
-	if ( $activity->type != 'new_groupblog_post' ) {
+	if ( $activity->type !== 'new_groupblog_post' && $activity->type !== 'new_groupblog_comment' ) {
 		return $retval;
 	}
 

--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1573,7 +1573,16 @@ function _bp_groupblog_set_activity_id_for_groupblog_comment( $retval, $r ) {
 	$r['type'] = 'new_groupblog_comment';
 	$r['item_id'] = buddypress()->activity->groupblog_temp_id;
 
-	return BP_Activity_Activity::get_id( $r );
+	return BP_Activity_Activity::get_id(
+		$r['user_id'],
+		$r['component'],
+		$r['type'],
+		$r['item_id'],
+		$r['secondary_item_id'],
+		$r['action'],
+		$r['content'],
+		$r['date_recorded']
+	);
 }
 
 /**

--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1307,20 +1307,12 @@ add_filter( 'bp_ajax_querystring', 'bp_groupblog_override_new_blog_post_activity
  * @since 1.8.4
  */
 function bp_groupblog_activity_can_comment( $retval ) {
-	if ( bp_get_activity_action_name() != 'new_groupblog_post' ) {
+	if ( 'new_groupblog_post' !== bp_get_activity_action_name() && 'new_groupblog_comment' !== bp_get_activity_action_name() ) {
 		return $retval;
 	}
 
-	global $bp;
-
-	// get activity reply setting for blog posts
-	$cannot_blog_comment = isset( $bp->site_options['bp-disable-blogforum-comments'] ) ? $bp->site_options['bp-disable-blogforum-comments'] : false;
-
-	if ( $cannot_blog_comment ) {
-		return false;
-	} else {
-		return $retval;
-	}
+	// Explicitly disable activity commenting on groupblog items.
+	return false;
 }
 add_filter( 'bp_activity_can_comment', 'bp_groupblog_activity_can_comment' );
 


### PR DESCRIPTION
This PR enables blog comment activity recording for groupblogs.

I'm doing some workarounds so we can piggyback on what BuddyPress is already doing for recording blog comments (those with the `new_blog_comment` type) and to utilize the activity API with `bp_activity_set_action()`, etc.

There are some slight drawbacks to this approach as hacking into BP's code in this manner makes things a little harder to read, due to the applying and removal of certain filters.

There are also limitations such as BuddyPress only recording public blog content:
https://buddypress.trac.wordpress.org/ticket/4831#comment:10

But, that's a different issue altogether.

@boonebgorges - Let me know what you think.