### PR TITLE
use passed $user_id rather than current in bp_groupblog_remove_user()

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -461,7 +461,7 @@ function bp_groupblog_remove_user( $group_id, $user_id = false ) {
 	$user->set_role( 'subscriber' );
 	wp_cache_delete( $user_id, 'users' );
 }
-add_action( 'groups_leave_group', 'bp_groupblog_remove_user' );
+add_action( 'groups_leave_group', 'bp_groupblog_remove_user', 10, 2 );
 
 /**
  * bp_groupblog_get_user_role( $user_id, $user_login, $blog_id )


### PR DESCRIPTION
I discovered that when the `groups_leave_group` action runs, `bp_groupblog_remove_user()` does not use the `$user_id` in the action but instead always defaults to `bp_loggedin_user_id()`. Calling `groups_leave_group()` with a different user does not update that user's role. This patch adds the correct `$accepted_args` parameter to fix it.