### PR TITLE
Use the group avatar on the Site Directory page for groupblogs

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1739,8 +1739,8 @@ function bp_groupblog_use_group_avatar_in_site_loop( $retval, $blog_id, $r ) {
 	}
 
 	// Already using a site icon, so bail.
-	$site_icon_alt = sprintf( esc_attr__( 'Site icon for %s', 'buddypress' ), bp_get_blog_name() );
-	if ( false !== strpos( $retval, $site_icon_alt ) ) {
+	$site_icon_thumb = bp_blogs_get_blogmeta( $blog_id, "site_icon_url_{$r['type']}" );
+	if ( ! empty( $site_icon_thumb ) ) {
 		return $retval;
 	}
 
@@ -1756,4 +1756,3 @@ function bp_groupblog_use_group_avatar_in_site_loop( $retval, $blog_id, $r ) {
 	) );
 }
 add_filter( 'bp_get_blog_avatar', 'bp_groupblog_use_group_avatar_in_site_loop', 10, 3 );
-

--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1739,8 +1739,8 @@ function bp_groupblog_use_group_avatar_in_site_loop( $retval, $blog_id, $r ) {
 	}
 
 	// Already using a site icon, so bail.
-	$site_icon_thumb = bp_blogs_get_blogmeta( $blog_id, "site_icon_url_{$r['type']}" );
-	if ( ! empty( $site_icon_thumb ) ) {
+	$site_icon = bp_blogs_get_blogmeta( $blog_id, "site_icon_url_{$r['type']}" );
+	if ( ! empty( $site_icon ) ) {
 		return $retval;
 	}
 

--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1718,4 +1718,42 @@ function bp_groupblog_delete_meta( $blog_id, $drop = false ) {
 }
 add_action('delete_blog', 'bp_groupblog_delete_meta', 10, 1);
 
-?>
+/**
+ * Use the group avatar on the Site Directory page for groupblogs.
+ *
+ * If a site in the site loop is a groupblog, use the group logo only if
+ * the site doesn't already have a customized site icon.
+ *
+ * @since 1.9.2
+ *
+ * @param  string $retval  Current site avatar
+ * @param  int    $blog_id Site ID in loop
+ * @param  array  $r       Avatar arguments
+ * @return string
+ */
+function bp_groupblog_use_group_avatar_in_site_loop( $retval, $blog_id, $r ) {
+	// Not a groupblog? Bail.
+	$group_id = get_groupblog_group_id( $blog_id );
+	if ( empty( $group_id ) ) {
+		return $retval;
+	}
+
+	// Already using a site icon, so bail.
+	$site_icon_alt = sprintf( esc_attr__( 'Site icon for %s', 'buddypress' ), bp_get_blog_name() );
+	if ( false !== strpos( $retval, $site_icon_alt ) ) {
+		return $retval;
+	}
+
+	// Site is using the site admin's avatar, so switch to group logo.
+	return bp_core_fetch_avatar( array(
+		'item_id'    => $group_id,
+		'avatar_dir' => 'group-avatars',
+		'object'     => 'group',
+		'type'       => $r['type'],
+		'alt'        => 'Group logo',
+		'width'      => $r['width'],
+		'height'     => $r['height'],
+	) );
+}
+add_filter( 'bp_get_blog_avatar', 'bp_groupblog_use_group_avatar_in_site_loop', 10, 3 );
+

--- a/readme.txt
+++ b/readme.txt
@@ -44,58 +44,6 @@ The BuddyPress Groupblog plugin extends the group functionality by enabling each
 
 5) You are done!
 
-== Other Notes ==
-
-**Known Issues:**
-
-* In order for Group Avatars to show on blogs please adjust the bp-core-avatars.php file. I realize this is a nono, but I don't see another way. Patches and ideas are welcome. For know adjust the last two functions for plugins/buddypress/bp-core/bp-core-avatars.php to the following:
-
-`
-/**
- * bp_core_avatar_upload_path()
- *
- * Returns the absolute upload path for the WP installation
- *
- * @global object $current_blog Current blog information
- * @uses wp_upload_dir To get upload directory info
- * @return string Absolute path to WP upload directory
- */
-function bp_core_avatar_upload_path() {
-	global $current_blog;
-
-	// Get upload directory information from current site
-	$upload_dir = wp_upload_dir();
-
-	// If multisite, and current blog does not match root blog, make adjustments
-	if ( bp_core_is_multisite() && BP_ROOT_BLOG != $current_blog->blog_id )
-		$upload_dir['basedir'] = WP_CONTENT_DIR . '/uploads/';
-
-	return apply_filters( 'bp_core_avatar_upload_path', $upload_dir['basedir'] );
-}
-
-/**
- * bp_core_avatar_url()
- *
- * Returns the raw base URL for root site upload location
- *
- * @global object $current_blog Current blog information
- * @uses wp_upload_dir To get upload directory info
- * @return string Full URL to current upload location
- */
-function bp_core_avatar_url() {
-	global $current_blog;
-
-	// Get upload directory information from current site
-	$upload_dir = wp_upload_dir();
-
-	// If multisite, and current blog does not match root blog, make adjustments
-	if ( bp_core_is_multisite() && BP_ROOT_BLOG != $current_blog->blog_id )
-		$upload_dir['baseurl'] = WP_CONTENT_URL . '/uploads';
-
-	return apply_filters( 'bp_core_avatar_url', $upload_dir['baseurl'] );
-}
-`
-
 == Screenshots ==
 
 1. Screenshot of the group blog creation stage.


### PR DESCRIPTION
When on the Site Directory page, if a site in the site loop is a groupblog, this PR will use the site's group logo only if the site doesn't already have a customized site icon.

In other words, no more site admin avatars :)