### PR TITLE
Delete 'bp_groupblog_blog_group_ids' cache on group deletion

### DIFF
--- a/bp-groupblog.php
+++ b/bp-groupblog.php
@@ -1921,6 +1921,19 @@ function bp_groupblog_delete_meta( $blog_id, $drop = false ) {
 add_action( 'delete_blog', 'bp_groupblog_delete_meta', 10, 1 );
 
 /**
+ * Deletes 'bp_groupblog_blog_group_ids' cache on group delete.
+ *
+ * @since 1.9.3
+ *
+ * @param int $group_id Group ID.
+ */
+function bp_groupblog_delete_meta_on_group_delete( $group_id ) {
+	$blog_id = get_groupblog_blog_id( $group_id );
+	wp_cache_delete( $blog_id, 'bp_groupblog_blog_group_ids' );
+}
+add_action( 'groups_before_delete_group', 'bp_groupblog_delete_meta_on_group_delete' );
+
+/**
  * Use the group avatar on the Site Directory page for groupblogs.
  *
  * If a site in the site loop is a groupblog, use the group logo only if


### PR DESCRIPTION
Hi Boone,

This PR fixes an issue where fetching the group ID for a site can return a non-existing group ID if the group is deleted.

We currently purge the `'bp_groupblog_blog_group_ids'` cache on site deletion and when uncoupling a site from a group. We need to do this on group deletion as well.